### PR TITLE
Longitude and latitude values for invalid postcodes no longer sent to cosmos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ __pycache__/
 /NCS.CDS.Address/host.json
 /NCS.CDS.Address/.gitignore
 /.gitattributes
+/NCS.DSS.Address/local.settings.json

--- a/NCS.DSS.Address/Models/Address.cs
+++ b/NCS.DSS.Address/Models/Address.cs
@@ -117,7 +117,9 @@ namespace NCS.DSS.Address.Models
         public void SetLongitudeAndLatitude(Position position)
         {
             if (position == null)
+            {
                 return;
+            }
 
             Longitude = (decimal)position.Lon;
             Latitude = (decimal)position.Lat;

--- a/NCS.DSS.Address/Models/AddressPatch.cs
+++ b/NCS.DSS.Address/Models/AddressPatch.cs
@@ -98,7 +98,9 @@ namespace NCS.DSS.Address.Models
         public void SetLongitudeAndLatitude(Position position)
         {
             if (position == null)
+            {
                 return;
+            }
 
             Longitude = (decimal)position.Lon;
             Latitude = (decimal)position.Lat;

--- a/NCS.DSS.Address/Models/AddressPatch.cs
+++ b/NCS.DSS.Address/Models/AddressPatch.cs
@@ -98,9 +98,7 @@ namespace NCS.DSS.Address.Models
         public void SetLongitudeAndLatitude(Position position)
         {
             if (position == null)
-            {
                 return;
-            }
 
             Longitude = (decimal)position.Lon;
             Latitude = (decimal)position.Lat;

--- a/NCS.DSS.Address/NCS.DSS.Address.csproj
+++ b/NCS.DSS.Address/NCS.DSS.Address.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />    
-    <PackageReference Include="DFC.GeoCoding.Standard" Version="1.0.5" />
+    <PackageReference Include="DFC.GeoCoding.Standard" Version="1.0.6" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
     <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />

--- a/NCS.DSS.Address/PatchAddressHttpTrigger/Function/PatchAddressHttpTrigger.cs
+++ b/NCS.DSS.Address/PatchAddressHttpTrigger/Function/PatchAddressHttpTrigger.cs
@@ -162,7 +162,7 @@ namespace NCS.DSS.Address.PatchAddressHttpTrigger.Function
                 }
 
                 addressPatchRequest.SetLongitudeAndLatitude(position);
-                _logger.LogInformation("Successfully set long and lat for postcode: {Postcode}", addressPatchRequest.PostCode);
+                _logger.LogInformation("Successfully set long and lat for postcode: {Postcode}. Longitude: {Longitude} Latitude: {Latitude} (null values imply given postcode is considered invalid)", addressPatchRequest.PostCode, addressPatchRequest.Longitude, addressPatchRequest.Latitude);
             }
 
             _logger.LogInformation("Checking if customer exists. Customer ID: {CustomerId}.", customerGuid);

--- a/NCS.DSS.Address/PatchAddressHttpTrigger/Service/AddressPatchService.cs
+++ b/NCS.DSS.Address/PatchAddressHttpTrigger/Service/AddressPatchService.cs
@@ -62,29 +62,33 @@ namespace NCS.DSS.Address.PatchAddressHttpTrigger.Service
             {
                 _jsonHelper.UpdatePropertyValue(obj["PostCode"], addressPatch.PostCode);
                 _logger.LogInformation("PostCode Update Complete in Json Object");
-            }
 
+                _jsonHelper.UpdatePropertyValue(obj["Longitude"], addressPatch.Longitude);
+                _logger.LogInformation("Longitude Update Complete in Json Object");
+
+                _jsonHelper.UpdatePropertyValue(obj["Latitude"], addressPatch.Latitude);
+                _logger.LogInformation("Latitude Update Complete in Json Object");
+            }
+            else
+            {
+                if (addressPatch.Longitude.HasValue)
+                {
+                    _jsonHelper.UpdatePropertyValue(obj["Longitude"], addressPatch.Longitude);
+                    _logger.LogInformation("Longitude Update Complete in Json Object");
+                }
+
+                if (addressPatch.Latitude.HasValue)
+                {
+                    _jsonHelper.UpdatePropertyValue(obj["Latitude"], addressPatch.Latitude);
+                    _logger.LogInformation("Latitude Update Complete in Json Object");
+                }
+            }
 
             if (addressPatch.AlternativePostCode != null)
             {
                 _jsonHelper.UpdatePropertyValue(obj["AlternativePostCode"], addressPatch.AlternativePostCode);
                 _logger.LogInformation("AlternativePostCode Update Complete in Json Object");
             }
-
-
-            if (addressPatch.Longitude.HasValue)
-            {
-                _jsonHelper.UpdatePropertyValue(obj["Longitude"], addressPatch.Longitude);
-                _logger.LogInformation("Longitude Update Complete in Json Object");
-            }
-
-
-            if (addressPatch.Latitude.HasValue)
-            {
-                _jsonHelper.UpdatePropertyValue(obj["Latitude"], addressPatch.Latitude);
-                _logger.LogInformation("Latitude Update Complete in Json Object");
-            }
-
 
             if (addressPatch.EffectiveFrom.HasValue)
             {

--- a/NCS.DSS.Address/PostAddressHttpTrigger/Function/PostAddressHttpTrigger.cs
+++ b/NCS.DSS.Address/PostAddressHttpTrigger/Function/PostAddressHttpTrigger.cs
@@ -153,7 +153,7 @@ namespace NCS.DSS.Address.PostAddressHttpTrigger.Function
             }
 
             addressRequest.SetLongitudeAndLatitude(position);
-            _logger.LogInformation("Successfully set long and lat for postcode: {Postcode}", addressRequest.PostCode);
+            _logger.LogInformation("Successfully set long and lat for postcode: {Postcode}. Longitude: {Longitude} Latitude: {Latitude} (null values imply given postcode is considered invalid)", addressRequest.PostCode, addressRequest.Longitude, addressRequest.Latitude);
 
             _logger.LogInformation("Checking if customer exists. Customer ID: {CustomerId}.", customerGuid);
             var doesCustomerExist = await _resourceHelper.DoesCustomerExist(customerGuid);
@@ -194,7 +194,6 @@ namespace NCS.DSS.Address.PostAddressHttpTrigger.Function
             _logger.LogInformation("Attempting to send message to Service Bus Namespace. Address GUID: {AddressId}", address.AddressId);
             await _addressPostService.SendToServiceBusQueueAsync(address, apimUrl);
             _logger.LogInformation("Successfully sent message to Service Bus. Address GUID: {AddressId}", address.AddressId);
-
 
             _logger.LogInformation("Function {FunctionName} has finished invoking", nameof(PostAddressHttpTrigger));
 


### PR DESCRIPTION
- Upgraded to DFC.GeoCoding.Standard which now deems postcode invalid is confidence score less than 0.9
- PATCH now adds NULL values for long and lat if a postcode was given. If no postcode given then behaviour is as before.
- Improved logging in POST and PATCH so that longitude and latitude values shown in log message