### PR TITLE
AD-260954: Migrate from Azure Maps to Ordnance Survey

### DIFF
--- a/NCS.DSS.Address/GeoCoding/GeoCodingService.cs
+++ b/NCS.DSS.Address/GeoCoding/GeoCodingService.cs
@@ -1,17 +1,17 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
-using DFC.GeoCoding.Standard.AzureMaps.Service;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Services;
 using Microsoft.Extensions.Logging;
 
 namespace NCS.DSS.Address.GeoCoding
 {
     public class GeoCodingService : IGeoCodingService
     {
-        private readonly IAzureMapService _azureMapService;
+        private readonly IOSService _OSService;
         private readonly ILogger<GeoCodingService> _logger;
 
-        public GeoCodingService(IAzureMapService azureMapService, ILogger<GeoCodingService> logger)
+        public GeoCodingService(IOSService OSService, ILogger<GeoCodingService> logger)
         {
-            _azureMapService = azureMapService;
+            _OSService = OSService;
             _logger = logger;
         }
 
@@ -25,7 +25,7 @@ namespace NCS.DSS.Address.GeoCoding
                 return null;
             }
 
-            var position = await _azureMapService.GetPositionForAddress(postcode);
+            var position = await _OSService.GetPositionForPostcodeAsync(postcode);
 
             if (position == null)
             {

--- a/NCS.DSS.Address/GeoCoding/IGeoCodingService.cs
+++ b/NCS.DSS.Address/GeoCoding/IGeoCodingService.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 
 namespace NCS.DSS.Address.GeoCoding
 {

--- a/NCS.DSS.Address/Models/Address.cs
+++ b/NCS.DSS.Address/Models/Address.cs
@@ -1,4 +1,4 @@
-using DFC.GeoCoding.Standard.AzureMaps.Model;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.JSON.Standard.Attributes;
 using DFC.Swagger.Standard.Annotations;
 using System.ComponentModel.DataAnnotations;
@@ -121,8 +121,8 @@ namespace NCS.DSS.Address.Models
                 return;
             }
 
-            Longitude = (decimal)position.Lon;
-            Latitude = (decimal)position.Lat;
+            Longitude = (decimal)position.Longitude;
+            Latitude = (decimal)position.Latitude;
         }
     }
 }

--- a/NCS.DSS.Address/Models/AddressConfigurationSettings.cs
+++ b/NCS.DSS.Address/Models/AddressConfigurationSettings.cs
@@ -16,10 +16,7 @@ namespace NCS.DSS.Address.Models
         public required string SearchServiceName { get; set; }
         public required string SearchServiceAdminApiKey { get; set; }
         public required string CustomerSearchIndexName { get; set; }
-        public required string AzureMapURL { get; set; }
-        public required string AzureMapApiVersion { get; set; }
-        public required string AzureMapSubscriptionKey { get; set; }
-        public required string AzureCountrySet { get; set; }
-
+        public required string OSServiceApiUrl { get; set; }
+        public required string OSServiceApiKey { get; set; }
     }
 }

--- a/NCS.DSS.Address/Models/AddressPatch.cs
+++ b/NCS.DSS.Address/Models/AddressPatch.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.Swagger.Standard.Annotations;
 using System.ComponentModel.DataAnnotations;
 
@@ -102,8 +102,8 @@ namespace NCS.DSS.Address.Models
                 return;
             }
 
-            Longitude = (decimal)position.Lon;
-            Latitude = (decimal)position.Lat;
+            Longitude = (decimal)position.Longitude;
+            Latitude = (decimal)position.Latitude;
         }
 
     }

--- a/NCS.DSS.Address/Models/IAddress.cs
+++ b/NCS.DSS.Address/Models/IAddress.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 
 namespace NCS.DSS.Address.Models
 {

--- a/NCS.DSS.Address/NCS.DSS.Address.csproj
+++ b/NCS.DSS.Address/NCS.DSS.Address.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />    
-    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.0.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.1.0" />    
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
     <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />

--- a/NCS.DSS.Address/NCS.DSS.Address.csproj
+++ b/NCS.DSS.Address/NCS.DSS.Address.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />    
-    <PackageReference Include="DFC.GeoCoding.Standard" Version="1.0.6" />
+    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.0.0" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
     <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />

--- a/NCS.DSS.Address/PatchAddressHttpTrigger/Function/PatchAddressHttpTrigger.cs
+++ b/NCS.DSS.Address/PatchAddressHttpTrigger/Function/PatchAddressHttpTrigger.cs
@@ -1,4 +1,4 @@
-using DFC.GeoCoding.Standard.AzureMaps.Model;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
 using Microsoft.AspNetCore.Http;

--- a/NCS.DSS.Address/PostAddressHttpTrigger/Function/PostAddressHttpTrigger.cs
+++ b/NCS.DSS.Address/PostAddressHttpTrigger/Function/PostAddressHttpTrigger.cs
@@ -1,4 +1,4 @@
-using DFC.GeoCoding.Standard.AzureMaps.Model;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
 using Microsoft.AspNetCore.Http;

--- a/NCS.DSS.Address/Program.cs
+++ b/NCS.DSS.Address/Program.cs
@@ -1,11 +1,13 @@
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
-using DFC.GeoCoding.Standard.AzureMaps.Service;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Services;
 using DFC.HTTP.Standard;
 using DFC.JSON.Standard;
 using DFC.Swagger.Standard;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -35,6 +37,12 @@ namespace NCS.DSS.Address
                     var configuration = context.Configuration;
                     services.AddOptions<AddressConfigurationSettings>()
                         .Bind(configuration);
+                    services.Configure<OSServiceOptions>(options =>
+                    {
+                        var settings = configuration.Get<AddressConfigurationSettings>();
+                        options.ApiUrl = settings.OSServiceApiUrl;
+                        options.ApiKey = settings.OSServiceApiKey;
+                    });
 
                     services.AddApplicationInsightsTelemetryWorkerService();
                     services.ConfigureFunctionsApplicationInsights();
@@ -51,9 +59,11 @@ namespace NCS.DSS.Address
                     services.AddTransient<IPatchAddressHttpTriggerService, PatchAddressHttpTriggerService>();
                     services.AddScoped<IAddressPatchService, AddressPatchService>();
                     services.AddScoped<IGeoCodingService, GeoCodingService>();
-                    services.AddScoped<IAzureMapService, AzureMapService>();
                     services.AddTransient<ICosmosDbProvider, CosmosDbProvider>();
                     services.AddTransient<IAddressServiceBusClient, AddressServiceBusClient>();
+
+                    services.AddHttpClient<IOSService, OSService>();
+
                     services.AddLogging();
 
                     services.AddSingleton(s =>

--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -5,12 +5,6 @@
         "appInsightsInstrumentationKey": {
             "value": "__appInsightsInstrumentationKey__" 
         },
-        "azureMapsApiVersion": {
-            "value": "__AzureMapsApiVersion__"
-        },
-        "azureMapsUrl": {
-            "value": "__AzureMapsUrl__"
-        },
         "cosmosDbCollectionId": {
             "value": "__ApiResourceName__"
         },

--- a/Resources/template.json
+++ b/Resources/template.json
@@ -5,12 +5,6 @@
         "appInsightsInstrumentationKey": {
             "type": "string"
         },
-        "azureMapsApiVersion": {
-            "type": "string"
-        },
-        "azureMapsUrl": {
-            "type": "string"
-        },
         "cosmosDbCollectionId": {
             "type": "string"
         },
@@ -49,9 +43,6 @@
                 "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
                 "FUNCTIONS_EXTENSION_VERSION": "~4",
                 "MSDEPLOY_RENAME_LOCKED_FILES": "1",
-                "AzureMapApiVersion": "[parameters('azureMapsApiVersion')]",
-                "AzureMapSubscriptionKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=AzureMapsAccessKey)', parameters('keyVaultName'))]",
-                "AzureMapURL": "[parameters('azureMapsUrl')]",
                 "AzureWebJobStorage": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=SharedStorageAccountConnectionString)', parameters('keyVaultName'))]",
                 "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('appInsightsInstrumentationKey')]",
                 "CollectionId": "[parameters('cosmosDbCollectionId')]",
@@ -60,11 +51,13 @@
                 "CustomerCollectionId": "customers",
                 "ServiceBusConnectionString": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=ServiceBusConnectionString)', parameters('keyVaultName'))]",
                 "QueueName": "[parameters('serviceBusQueueName')]",
-                "AzureCountrySet": "GB",
                 "CustomerSearchIndexName": "customer-search-index-v2",
                 "SearchServiceName": "[parameters('SearchServiceName')]",
                 "SearchServiceAdminApiKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=SharedSearchAdminKey)', parameters('keyVaultName'))]",
-                "CosmosDbEndpoint": "[parameters('CosmosDbEndpoint')]"
+                "CosmosDbEndpoint": "[parameters('CosmosDbEndpoint')]",
+				"OSServiceApiUrl": "https://api.os.uk/search/places/v1/postcode?postcode={0}&dataset=DPA&output_srs=WGS84",
+				"OSServiceApiKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=GetPostCodeApiKey)', parameters('keyVaultName'))]"
+			
             },
             "copy": {
                 "name": "FunctionAppSettingsCopy",


### PR DESCRIPTION
This pull request migrates the geocoding functionality from using Azure Maps to the Ordnance Survey (OS) geocoding service. The changes update service dependencies, configuration, and code references throughout the application to use the new OS service, and remove all Azure Maps-specific code and configuration.

**Migration from Azure Maps to Ordnance Survey geocoding:**

* Updated all references in code files to use `DFC.GeoCoding.Standard.OrdnanceSurvey.Models` and `DFC.GeoCoding.Standard.OrdnanceSurvey.Services` instead of the Azure Maps equivalents, including in models, service interfaces, and HTTP trigger functions. 
* Changed the implementation of `GeoCodingService` to depend on `IOSService` and call `GetPositionForPostcodeAsync`, replacing the previous dependency on `IAzureMapService` and its method. 
* Updated the `SetLongitudeAndLatitude` methods in `Address` and `AddressPatch` to use `Longitude` and `Latitude` properties from the new OS `Position` model, replacing `Lon` and `Lat` from Azure Maps. 

**Configuration and dependency injection updates:**

* Replaced Azure Maps configuration settings (`AzureMapURL`, `AzureMapApiVersion`, etc.) with OS service settings (`OSServiceApiUrl`, `OSServiceApiKey`) in `AddressConfigurationSettings` and updated the application configuration and dependency injection to provide these settings to the new OS service.
* Registered the OS geocoding service (`IOSService`, `OSService`) with the dependency injection container and removed Azure Maps service registration.

**Infrastructure and deployment changes:**

* Updated the NuGet package reference to `DFC.GeoCoding.Standard` to version 2.1.0 to support Ordnance Survey.
* Removed Azure Maps-related parameters and environment variables from deployment templates (`parameters.json` and `template.json`), and added new parameters and environment variables for the OS service API.